### PR TITLE
add message history to admin

### DIFF
--- a/app/admin/conversations.rb
+++ b/app/admin/conversations.rb
@@ -1,0 +1,27 @@
+ActiveAdmin.register Conversation do
+  actions :show, :index
+
+  show do |conversation|
+    attributes_table do
+      row :id
+
+      attributes_table_for conversation.users do
+        row :id
+        row :full_name
+        row :email
+      end
+    end
+
+    status_tag 'Messages'
+    messages = conversation.messages
+    paginated_collection(messages.page(params[:page]).per(10),
+                         download_links: false) do
+      table_for(messages) do
+        column 'ID', :id
+        column 'User', :user
+        column 'Text', :text
+        column 'Created at', :created_at
+      end
+    end
+  end
+end

--- a/app/admin/messages.rb
+++ b/app/admin/messages.rb
@@ -1,0 +1,6 @@
+ActiveAdmin.register Conversation
+ActiveAdmin.register Message do
+  belongs_to :conversation
+  actions :show, :index
+  permit_params :text, :user, :created_at, :id
+end


### PR DESCRIPTION
Admin can expand a conversation seeing belonging users and the message history on it

![Screen Shot 2019-10-10 at 11 18 04 AM](https://user-images.githubusercontent.com/53769770/66577573-04af0200-eb50-11e9-9838-c6166001fedc.png)
